### PR TITLE
Add query to fetch Product Metafields

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The goal is to make creating an mobile app from your Shopify website easier.
      Future<List<Product>> getAllProductsFromCollectionById(String id)
      Future<List<Product>> getAllProductsOnQuery(String cursor, SortKeyProduct sortKey, String query)
      Future<List<Product>> getXProductsOnQueryAfterCursor(String cursor, int limit, SortKeyProduct sortKey, String query)
+     Future<List<Metafield>> getMetafieldsFromProduct(String productHandle, {String namespace})
 ```
 ```dart
   ShopifyCheckout shopifyCheckout = ShopifyCheckout.instance;

--- a/lib/graphql_operations/queries/get_metafileds_from_product.dart
+++ b/lib/graphql_operations/queries/get_metafileds_from_product.dart
@@ -1,0 +1,18 @@
+const String getMetafieldsFromProductQuery = r'''
+query($handle: String!, $namespace: String!) {
+  productByHandle(handle: $handle) {
+    metafields(first: 250, namespace: $namespace) {
+      edges {
+        node {
+          id
+          namespace
+          key
+          value
+          valueType
+          description
+        }
+      }
+    }
+  }
+}
+ ''';

--- a/lib/models/src/product.dart
+++ b/lib/models/src/product.dart
@@ -210,6 +210,33 @@ class ProductVariant {
   }
 }
 
+class Metafield {
+  final String id;
+  final String namespace;
+  final String key;
+  final String value;
+  final String valueType;
+  final String description;
+
+  const Metafield(
+      {this.id,
+      this.namespace,
+      this.key,
+      this.value,
+      this.valueType,
+      this.description});
+
+  static Metafield fromJson(Map<String, dynamic> json) {
+    return Metafield(
+        id: (json['node'] ?? const {})['id'],
+        namespace: (json['node'] ?? const {})['namespace'],
+        key: (json['node'] ?? const {})['key'],
+        value: (json['node'] ?? const {})['value'],
+        valueType: (json['node'] ?? const {})['valueType'],
+        description: (json['node'] ?? const {})['description']);
+  }
+}
+
 class Option {
   final String id;
   final String name;


### PR DESCRIPTION
Add the option to fetch Metafields for a specific product.

It's a bit tricky and not very well explained. See this doc for further reference https://shopify.dev/tutorials/retrieve-metafields-with-storefront-api

I've dug in during all the morning, ask me if you have any question.