### PR TITLE
Fixed issues

### DIFF
--- a/lib/graphql_operations/queries/get_all_blogs.dart
+++ b/lib/graphql_operations/queries/get_all_blogs.dart
@@ -1,5 +1,5 @@
 const String getAllBlogsQuery = r'''
-query getBlogs($reverseBlogs: Boolean, $reverseArticles: Boolean, $sortKey: BlogSortkeys ){
+query getBlogs($reverseBlogs: Boolean, $reverseArticles: Boolean, $sortKey: BlogSortKeys ){
   blogs(first: 250, sortKey: $sortKey, reverse: $reverseBlogs) {
     edges {
       node {

--- a/lib/graphql_operations/queries/get_n_articles_sorted.dart
+++ b/lib/graphql_operations/queries/get_n_articles_sorted.dart
@@ -1,5 +1,5 @@
 const String getNArticlesSortedQuery = r'''
-query($x : Int, $sortKey : ArticleSortKeys, reverse: Boolean){
+query($x : Int, $sortKey : ArticleSortKeys, $reverse: Boolean){
   articles(first: $x, sortKey: $sortKey, reverse: $reverse) {
     edges {
       node {

--- a/lib/models/src/product.dart
+++ b/lib/models/src/product.dart
@@ -123,6 +123,7 @@ class Product {
 
   static _getImageList(Map<String, dynamic> json) {
     List<ShopifyImage> imageList = [];
+    if (json != null && json['edges'] != null)
     json['edges'].forEach((image) => imageList.add(ShopifyImage.fromJson(image['node'] ?? const {})));
     return imageList;
   }


### PR DESCRIPTION
These typos caused `shopifyBlog.getXArticlesSorted` and `shopifyBlog.getAllBlogs` methods of to fail. Now they work properly.