### PR TITLE
Fix nullable sortKeys

### DIFF
--- a/lib/shopify/src/shopify_store.dart
+++ b/lib/shopify/src/shopify_store.dart
@@ -374,7 +374,7 @@ class ShopifyStore with ShopifyError{
           documentNode: gql(getAllProductsOnQueryQuery),
           variables: {
             'cursor': cursor,
-            'sortKey': sortKey.parseToString(),
+            'sortKey': sortKey?.parseToString(),
             'query': query,
             'reverse': reverse
           });
@@ -405,7 +405,7 @@ class ShopifyStore with ShopifyError{
         variables: {
           'cursor': cursor,
           'limit': limit,
-          'sortKey': sortKey.parseToString(),
+          'sortKey': sortKey?.parseToString(),
           'query': query,
           'reverse': reverse
         });


### PR DESCRIPTION
The not required and so nullable parameter `sortKey` causes an exception if it is null and `parseToString()` is called